### PR TITLE
Remove url hash when the Active Users tab is clicked

### DIFF
--- a/haml/app.haml
+++ b/haml/app.haml
@@ -44,6 +44,7 @@
 
     $('#tabs li.sessions').click(function(){
       FnordMetric.renderSessionView();
+      window.location.hash = '';
     });
 
     $('#tabs li').click(function(){


### PR DESCRIPTION
After a widget tab is clicked,  a hash is append after the URL.
But when clicking the tab "Active Users", the hash isn't removed.

This commit removes all hash tags.
Alternatively, we can add a rel attribute to the Active Users tab. (e.g. #ActiveUsers)
