### PR TITLE
Add dependency status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ FnordMetric
 
 FnordMetric is a highly configurable (and pretty fast) realtime app/event tracking thing based on ruby eventmachine and redis. You define your own plotting and counting functions as ruby blocks!
 
-[ ![Build status - Travis-ci](https://secure.travis-ci.org/paulasmuth/fnordmetric.png) ](http://travis-ci.org/paulasmuth/fnordmetric)
+[ ![Build status - Travis-ci](https://secure.travis-ci.org/paulasmuth/fnordmetric.png) ](http://travis-ci.org/paulasmuth/fnordmetric) [ ![Dependency status - Gemnasium](https://gemnasium.com/paulasmuth/fnordmetric.png) ](https://gemnasium.com/paulasmuth/fnordmetric)
 
 [SCREENCAST](http://www.screenr.com/KiJs): the FnordMetric-instance we use to track our social dating app.
 


### PR DESCRIPTION
The dependency status of the project via Gemnasium relays how up-to-date fnordmetric's gem dependencies are with the latest versions. And fnordmetric is very close to up-to-date.
