### PR TITLE
Only parsable events are added to event queue by inbound stream

### DIFF
--- a/lib/fnordmetric/inbound_stream.rb
+++ b/lib/fnordmetric/inbound_stream.rb
@@ -1,66 +1,80 @@
-class FnordMetric::InboundStream < EventMachine::Connection 
+class FnordMetric::InboundStream < EventMachine::Connection
+  module Logic
+    def self.opts=(opts)
+      @@opts = opts
+    end
 
-  @@opts = nil
+    @@em = EM
+    def self.em=(em)
+      @@em = em
+    end
+
+    def receive_data(chunk)
+      @buffer << chunk
+      @@em.defer{ next_event }
+    end
+
+    def push_event(event_id, event_data)    
+      prefix = @@opts[:redis_prefix]
+
+      JSON.parse(event_data)
+      @redis.hincrby "#{prefix}-stats",             "events_received", 1
+      @redis.set     "#{prefix}-event-#{event_id}", event_data
+      @redis.lpush   "#{prefix}-queue",             event_id       
+      @redis.expire  "#{prefix}-event-#{event_id}", @@opts[:event_queue_ttl]
+    rescue JSON::ParserError
+    ensure
+      @events_buffered -= 1
+      close_connection?
+    end
+    
+    def next_event
+      read_next_event
+      push_next_event
+    end
+    
+    def read_next_event
+      while (event = @buffer.slice!(/^(.*)\n/))
+        @events_buffered += 1
+        @events << event
+      end 
+    end
+
+    def push_next_event
+      return true if @events.empty?
+      push_event(get_next_uuid, @events.pop) 
+      @@em.next_tick(&method(:push_next_event))    
+    end
+
+    def get_next_uuid
+      rand(9999999999999999999).to_s # FIXME
+    end
+
+    def close_connection?
+      @redis.quit unless @streaming || (@events_buffered!=0) 
+    end
+
+    def post_init
+      @redis = Redis.connect(:url => @@opts[:redis_url])
+      @events_buffered = 0
+      @streaming = true
+      @buffer = ""
+      @events = []          
+    end
+
+    def unbind
+      @streaming = false
+      close_connection?
+    end
+  end
+
+  Logic.opts = nil
+
+  include Logic
 
   def self.start(opts)
-    @@opts = opts
-    EM.start_server(*opts[:inbound_stream], self)    
+    Logic.opts = opts
+    EM.start_server(*opts[:inbound_stream], self)
   end
-
-  def receive_data(chunk)        
-    @buffer << chunk         
-    EM.defer{ next_event }
-  end
-
-  def push_event(event_id, event_data)    
-    prefix = @@opts[:redis_prefix]
-        
-    @redis.hincrby "#{prefix}-stats",             "events_received", 1
-    @redis.set     "#{prefix}-event-#{event_id}", event_data
-    @redis.lpush   "#{prefix}-queue",             event_id       
-    @redis.expire  "#{prefix}-event-#{event_id}", @@opts[:event_queue_ttl]
-    
-    @events_buffered -= 1
-    close_connection?
-  end
-  
-  def next_event
-    read_next_event
-    push_next_event
-  end
-  
-  def read_next_event
-    while (event = @buffer.slice!(/^(.*)\n/))
-      @events_buffered += 1
-      @events << event
-    end 
-  end
-
-  def push_next_event
-    return true if @events.empty?
-    push_event(get_next_uuid, @events.pop) 
-    EM.next_tick(&method(:push_next_event))    
-  end
-
-  def get_next_uuid
-    rand(9999999999999999999).to_s # FIXME
-  end
-
-  def close_connection?
-    @redis.quit unless @streaming || (@events_buffered!=0) 
-  end
-
-  def post_init
-    @redis = Redis.connect(:url => @@opts[:redis_url])
-    @events_buffered = 0
-    @streaming = true
-    @buffer = ""
-    @events = []          
-  end
-
-  def unbind
-    @streaming = false
-    close_connection?
-  end
-
 end
+

--- a/spec/inbound_stream_spec.rb
+++ b/spec/inbound_stream_spec.rb
@@ -1,0 +1,46 @@
+require ::File.expand_path('../spec_helper.rb', __FILE__)
+
+describe FnordMetric::InboundStream do
+  class TestStream
+    module TestEM
+      def self.defer; yield; end
+      def self.next_tick; yield; end
+    end
+
+    FnordMetric::InboundStream::Logic.em = TestEM
+    FnordMetric::InboundStream::Logic.opts =
+      {redis_url: "redis://localhost:6379",
+        redis_prefix: "fnordmetric-test", event_queue_ttl: 120}
+
+    include FnordMetric::InboundStream::Logic
+  end
+
+  let(:inbound_stream) do
+    TestStream.new.tap do |logic|
+      logic.post_init
+    end
+  end
+
+  let(:redis) { inbound_stream.instance_variable_get("@redis") }
+
+  after { inbound_stream.unbind }
+
+  describe "pushing new events" do
+    it "should add parsable event to the queue" do
+      data = %Q{{"_type": "started"}\n}
+
+      lambda {
+        inbound_stream.receive_data data
+      }.should change { redis.llen("fnordmetric-test-queue") }.by +1
+    end
+
+    it "should reject non parsable events" do
+      broken_data = %Q{{"_type": \n"started"}\n}
+
+      lambda {
+        inbound_stream.receive_data broken_data
+      }.should_not change { redis.llen("fnordmetric-test-queue") }
+    end
+  end
+end
+


### PR DESCRIPTION
Events with invalid JSON data can't be added to event queue any more.

I also decoupled InboundStream and EM so now InboundStream Logic can be easily tested.

Before the commit doing:

`echo 'blah {' | nc localhost 1337`

would brake my events. Now events are bullet proof ;-)
