### PR TITLE
Added .rvmrc to the Git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ rdoc
 .bundle
 pkg
 db/*.sqlite
+.rvmrc


### PR DESCRIPTION
I think we can at least agree that there are a large number of users who
will be using RVM with their project. However, since there is a want to
be agnostic to tools such as rvmrc I have added an addition to the
.gitignore file.
