### PR TITLE
Changed z-index for top-bar

### DIFF
--- a/pub/fnordmetric.css
+++ b/pub/fnordmetric.css
@@ -4,7 +4,7 @@ body{ background:#3b3e45; color:#333; margin:0; padding:0; overflow-y:scroll; fo
 .shown{ display: block; }
 .hidden{ display: none; }
 
-.topbar{ height:38px; background:#24272c; position:fixed; top:0px; width:100%;}
+.topbar{ height:38px; background:#24272c; position:fixed; top:0px; width:100%; z-index: 1}
 .topbar ul { list-style-type:none; margin:0; }
 .topbar ul li { padding: 5px 10px 5px 10px; background-color:#3b3e45; display:inline; height:38px; line-height:38px; border-radius:3px; margin-right:5px;}
 .topbar ul li a { color:#ccc; font-size:13px; text-decoration:none; }


### PR DESCRIPTION
If you scrolled down the page, the top bar would go underneath of the charts.
With a z-index of 1, this no longer happens. I have verified the issue and
fix in firefox 6.0.2 and chrome 16.0.912.75
