### PR TITLE
respect gauge max_fields option

### DIFF
--- a/lib/fnordmetric/gauge_calculations.rb
+++ b/lib/fnordmetric/gauge_calculations.rb
@@ -46,7 +46,7 @@ module FnordMetric::GaugeCalculations
   end
 
   def field_values_at(time, opts={}, &block)
-    opts[:max_fields] ||= 50
+    opts[:max_fields] ||= @opts[:max_fields] || 50
     redis.zrevrange(
       tick_key(time), 
       0, opts[:max_fields]-1, 


### PR DESCRIPTION
In a widget like toplist, use a gauges max_field option to limit how many results show up

```
gauge :test, 
  :tick => 1.hour.to_i, 
  :title => "test",
  :max_fields => 2,
  :three_dimensional => true
```

should only show the top 2 items 
