### PR TITLE
Use ticks.max, instead of ticks.last to correct error caused when tick c...

### DIFF
--- a/lib/fnordmetric/timeline_widget.rb
+++ b/lib/fnordmetric/timeline_widget.rb
@@ -7,7 +7,7 @@ class FnordMetric::TimelineWidget  < FnordMetric::Widget
       :gauges => gauges.map(&:name),
       :gauge_titles => gauge_titles,
       :start_timestamp => ticks.first,
-      :end_timestamp => ticks.last,
+      :end_timestamp => ticks.max,
       :autoupdate => (@opts[:autoupdate] || 60),
       :include_current => !!@opts[:include_current],
       :plot_style => (@opts[:plot_style] || 'line'),


### PR DESCRIPTION
...lass is converted to an Enumerator, instead of a range.  :max method exists in both range and enumerator.

undefined method `last' for #<Enumerator
