### PR TITLE
removed 'in_groups_of(2)' since is will not work in more recent redis-ve...

### DIFF
--- a/lib/fnordmetric/gauge_calculations.rb
+++ b/lib/fnordmetric/gauge_calculations.rb
@@ -51,7 +51,7 @@ module FnordMetric::GaugeCalculations
       tick_key(time), 
       0, opts[:max_fields]-1, 
       :withscores => true
-    ).in_groups_of(2).map do |key, val|
+    ).map do |key, val|
       [key, calculate_value(val, time, opts, block)]
     end
   end


### PR DESCRIPTION
...rsions (~ 2.2.5+)
