### PR TITLE
Use default_options in FnordMetric::App initialize

### DIFF
--- a/lib/fnordmetric/web/app.rb
+++ b/lib/fnordmetric/web/app.rb
@@ -22,11 +22,11 @@ class FnordMetric::App < Sinatra::Base
     include FnordMetric::AppHelpers
   end
 
-  def initialize(opts)
-    @opts = opts
+  def initialize(opts = {})
+    @opts = FnordMetric.default_options(opts)
 
     @namespaces = FnordMetric.namespaces
-    @redis = Redis.connect(:url => opts[:redis_url])
+    @redis = Redis.connect(:url => @opts[:redis_url])
 
     super(nil)
   end


### PR DESCRIPTION
When mounting App in Rails it fails with 0 arguments for 1 expected. This fixes it. Use default_options like in FnordMetric::API
