### PR TITLE
Fixed script tag

### DIFF
--- a/web/haml/app.haml
+++ b/web/haml/app.haml
@@ -16,7 +16,7 @@
     %script{:src => "/js/fnordmetric.pie_widget.js", :type => "text/javascript"}
     %script{:src => "/js/fnordmetric.toplist_widget.js", :type => "text/javascript"}
     %script{:src => "/js/fnordmetric.html_widget.js", :type => "text/javascript"}
-    %script{:src => "/js/fnordmetric.realtime_value_widget.js", :type => "text/javascript"}
+    %script{:src => "/js/fnordmetric.realtime_timeline_widget.js", :type => "text/javascript"}
     %script{:src => "/js/fnordmetric.timeseries_widget.js", :type => "text/javascript"}
     %script{:src => "/js/fnordmetric.overview_view.js", :type => "text/javascript"}
     %script{:src => "/js/fnordmetric.gauge_view.js", :type => "text/javascript"}


### PR DESCRIPTION
The script tag that requires fnordmetric.realtime_value_widget should be fnormedtric.realtime_timeline_widget as it was renamed in this commit https://github.com/paulasmuth/fnordmetric/commit/1da7a9115a41347e646b6319984d37f9efdb6571
