### PR TITLE
Full example fixed because it does not work in Ruby 1.9.2.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -289,7 +289,7 @@ def start_example_data_generator
     loop do
       api.event(:_type => :signup, :referrer => (rand(3) == 1 ? :twitter : :facebook))
       api.event(:_type => :search, :keyword => (%w(Donau Dampf Schiff Fahrts Kaptitaens Muetzen Staender).shuffle[0..2] * ""))
-      api.event(:_type => :user_demography, :age => rand(15..85), :gender => (rand(2)==1 ? :female : :male) )
+      api.event(:_type => :user_demography, :age => [*15..85].sample, :gender => (rand(2)==1 ? :female : :male) )
       sleep (rand(10)/10.to_f)
     end
   end


### PR DESCRIPTION
rand(15..85) does not work in ruby 1.9.2. 

Changed to [*15..85].sample to make it work in ruby 1.9.2 and 1.9.3
