### PR TITLE
Prevent memory leak when timeline is disabled with many incoming events

### DIFF
--- a/lib/fnordmetric/namespace.rb
+++ b/lib/fnordmetric/namespace.rb
@@ -20,9 +20,12 @@ class FnordMetric::Namespace
     self
   end
 
-  def announce(event)                  
-    announce_to_timeline(event)
-    announce_to_typelist(event)
+  def announce(event)
+    
+    if active_users_available
+      announce_to_timeline(event)
+      announce_to_typelist(event)
+    end
     
     if event[:_session]
       event[:_session_key] = announce_to_session(event).session_key 
@@ -48,6 +51,8 @@ class FnordMetric::Namespace
   end
 
   def announce_to_timeline(event)
+    puts 'test'
+    log 'test'
     timeline_key = key_prefix(:timeline)
     @redis.zadd(timeline_key, event[:_time], event[:_eid])
   end


### PR DESCRIPTION
To save memory usage for a webapp that generates lots of realtime events, I disabled active_users_available so Redis won't run out of memory. This wasn't enough, as the timeline and typelist are still updated internally. This patch will prevent Redis running out of memory in case active_users_available is disabled.
