### PR TITLE
Update Gemfile source due to deprecation warnings.

### DIFF
--- a/fnordmetric-core/Gemfile
+++ b/fnordmetric-core/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/fnordmetric-doc/Gemfile
+++ b/fnordmetric-doc/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "sinatra", "1.3.3"
 gem "sinatra-static", "0.1.1"


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
