### PR TITLE
Use options instead default_options.

### DIFF
--- a/fnordmetric-core/lib/fnordmetric/web/app.rb
+++ b/fnordmetric-core/lib/fnordmetric/web/app.rb
@@ -28,7 +28,7 @@ class FnordMetric::App < Sinatra::Base
   end
 
   def initialize(opts = {})
-    @opts = FnordMetric.default_options(opts)
+    @opts = FnordMetric.options(opts)
 
     @namespaces = FnordMetric.namespaces
     @redis = Redis.connect(:url => @opts[:redis_url])


### PR DESCRIPTION
Fnordmetric.default_options doesn't respect options set by the user
via Fnordmetric.options = {some: 'option'}.

This should solve https://github.com/paulasmuth/fnordmetric/126
