### PR TITLE
Fix Bug in Timeseries Widget of "undefined method last"

### DIFF
--- a/fnordmetric-core/lib/fnordmetric/widgets/timeseries_widget.rb
+++ b/fnordmetric-core/lib/fnordmetric/widgets/timeseries_widget.rb
@@ -32,7 +32,7 @@ class FnordMetric::TimeseriesWidget < FnordMetric::Widget
       :series => series,
       :gauges => gauges.map(&:name),
       :start_timestamp => ticks.first,
-      :end_timestamp => ticks.last,
+      :end_timestamp => ticks.max,
       :xticks => (@opts[:xticks] || 30),
       :autoupdate => (@opts[:autoupdate] || 60),
       :include_current => !!@opts[:include_current],


### PR DESCRIPTION
There is a bug in the timeseries widget codes. Changed method to ticks.max instead of ticks.last for the enumerator class in timeseries widget.
