### PR TITLE
Timeseries Widget: convert tick Enum to Arr for .last

### DIFF
--- a/fnordmetric-core/lib/fnordmetric/widgets/timeseries_widget.rb
+++ b/fnordmetric-core/lib/fnordmetric/widgets/timeseries_widget.rb
@@ -32,7 +32,7 @@ class FnordMetric::TimeseriesWidget < FnordMetric::Widget
       :series => series,
       :gauges => gauges.map(&:name),
       :start_timestamp => ticks.first,
-      :end_timestamp => ticks.last,
+      :end_timestamp => ticks.to_a.last,
       :xticks => (@opts[:xticks] || 30),
       :autoupdate => (@opts[:autoupdate] || 60),
       :include_current => !!@opts[:include_current],


### PR DESCRIPTION
Avoid NoMethodError on tick.last by converting it to array

```
NoMethodError - undefined method `last' for #<Enumerator: 1377191030..1377191330:step(10)>
/var/lib/gems/1.9.1/gems/fnordmetric-1.2.9/lib/fnordmetric/widgets/timeseries_widget.rb:35:in `data'
/var/lib/gems/1.9.1/gems/fnordmetric-1.2.9/lib/fnordmetric/widget.rb:75:in `render'
```
