### PR TITLE
Fixed Logger module

### DIFF
--- a/fnordmetric-core/lib/fnordmetric/logger.rb
+++ b/fnordmetric-core/lib/fnordmetric/logger.rb
@@ -21,7 +21,6 @@ class FnordMetric::Logger
   end
 
   def initialize(opts)
-    @namespaces = FnordMetric.namespaces
     @opts = FnordMetric.options(opts)
     opts.fetch(:file)
     @channels = @opts[:channels] || []


### PR DESCRIPTION
The Logger module has not been working for a long time, due to changes in the internal structure of FnordMetric.

Now it has been changed to use the pubsub messages emitted by the Worker module.
