### PR TITLE
require active_support before active_support/core_ext

### DIFF
--- a/fnordmetric-core/lib/fnordmetric.rb
+++ b/fnordmetric-core/lib/fnordmetric.rb
@@ -1,6 +1,7 @@
 require "eventmachine"
 require 'em-hiredis'
 require 'redis'
+require "active_support"
 require "active_support/core_ext"
 require 'yajl'
 require 'sinatra/base'


### PR DESCRIPTION
fixes ActiveSupport::Autoload error, and is the correct way to include ActiveSupport according to this thread: https://github.com/rails/rails/issues/14664
