### PR TITLE
Correct syntax for IMPORT statement in first example.

### DIFF
--- a/fnordmetric-doc/documentation/getting_started_with_fnordmetric_cli.md
+++ b/fnordmetric-doc/documentation/getting_started_with_fnordmetric_cli.md
@@ -26,7 +26,7 @@ where the content looks similar to this:
 
 Download city_temperatures.csv to a folder on your system. Within the same folder create another file called example_query.sql with the following content:
 
-    IMPORT city_temperatures FROM "csv://city_temperatures.csv?headers=true"
+    IMPORT TABLE city_temperatures FROM "csv://city_temperatures.csv?headers=true"
 
     SELECT * FROM city_temperatures;
 


### PR DESCRIPTION
The IMPORT statement applied invalid syntax IMPORT {identifier} FROM ..., missing the IMPORT TABLE {identifier}.  This popped up the error "unexpected token T_IDENTIFIER: city_temperatures, expected: 'T_TABLE' while executing query".  Corrected the usage.
